### PR TITLE
Data Simplifying

### DIFF
--- a/tokyo_json/README.md
+++ b/tokyo_json/README.md
@@ -1,5 +1,0 @@
-https://nlftp.mlit.go.jp/index.html
-
-国土交通省が提供するGIS行政棟境界ファイルを使用しました。
-
-I used the GIS administrative boundary file provided by Japan's Ministry of Land, Infrastructure and Transport.

--- a/trvster/main/views.py
+++ b/trvster/main/views.py
@@ -2,9 +2,15 @@ from django.shortcuts import render
 from rest_framework.views import APIView
 
 import folium
+import json
 
 def maptest(request):
-    map = folium.Map(location=[35.672868, 139.767158], zoom_start=16)
+    with open('./tokyo_json/tokyogeo_ku.geojson','r') as geo:
+        tokyo_geo = json.load(geo)
+    map = folium.Map(location=[35.672868, 139.767158], zoom_start=10)
+    folium.GeoJson(
+        tokyo_geo,
+        name='tokyoGeo'
+    ).add_to(map)
     maps=map._repr_html_()
-
     return render(request,'../templates/main.html',{'map' : maps})

--- a/trvster/tokyo_json/README.md
+++ b/trvster/tokyo_json/README.md
@@ -1,0 +1,5 @@
+https://nlftp.mlit.go.jp/index.html
+
+国土交通省が提供するGIS行政棟境界ファイルを使用しました。
+
+I used the GIS administrative boundary file provided by Japan's Ministry of Land, Infrastructure and Transport.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/81455273/221410668-f84c4402-cb62-4ec4-be50-210a9fb27b14.png)

Except for the Tokyo-based islands and Tokyo-based suburbs, only major districts were included
東京都所在の島々と東京外郭地域を除き、主要区のみ含まれるようにした。
